### PR TITLE
Translate docs/index

### DIFF
--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -1,0 +1,35 @@
+---
+title: Gatsby.js Documentation
+disableTableOfContents: true
+---
+
+import EmailCaptureForm from "../../www/src/components/email-capture-form"
+
+Gatsby is a blazing fast modern site generator for React.
+
+## Get Started
+
+There are two main ways to get started with Gatsby:
+
+1. [Tutorial](/tutorial/): Step-by-step instructions on how to install Gatsby and start a project: written for people without Gatsby or web development experience, though these learning resources have helped developers of all skill levels.
+2. [Quick start](/docs/quick-start): One page summary of how to install Gatsby and start a new project.
+
+## Go further
+
+1. [Recipes](/docs/recipes/): Find some quick answers for how to accomplish some specific, common tasks with Gatsby.
+2. Choose your own adventure and peruse the various sections of the Gatsby docs:
+
+   - [Reference Guides](/docs/guides/): Learn about the many different topics around building with Gatsby, like sourcing data, deployment, and more.
+   - [Gatsby API Reference](/docs/api-reference/): Learn more about Gatsby APIs and configuration.
+   - [Releases & Migration](/docs/releases-and-migration/): Find release notes and guides for migration between major versions.
+   - [Conceptual Guide](/docs/conceptual-guide/): Read high-level overviews of the Gatsby approach.
+   - [Gatsby Internals](/docs/gatsby-internals/): Dig into how Gatsby works behind the scenes.
+   - [Using Gatsby Professionally](/docs/using-gatsby-professionally/): Learn tips and tricks for how to explain Gatsby to others at work, so that you have more opportunities to work with Gatsby professionally.
+
+3. Check out the [Ecosystem](/ecosystem/) libraries for Gatsby starters and plugins, as well as external community resources.
+
+## Start contributing
+
+Visit the [Contributing](/contributing/) section to find guides on the Gatsby community, code of conduct, and how to get started contributing to Gatsby.
+
+<EmailCaptureForm signupMessage="Want to keep up with the latest tips &amp; tricks? Subscribe to our newsletter!" />

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -1,35 +1,35 @@
 ---
-title: Gatsby.js Documentation
+title: Dokumentasi Gatsby.js
 disableTableOfContents: true
 ---
 
 import EmailCaptureForm from "../../www/src/components/email-capture-form"
 
-Gatsby is a blazing fast modern site generator for React.
+Gatsby adalah sebuah *generator* situs modern yang cepat untuk React.
 
-## Get Started
+## Memulai
 
-There are two main ways to get started with Gatsby:
+Ada dua cara utama untuk memulai dengan Gatsby:
 
-1. [Tutorial](/tutorial/): Step-by-step instructions on how to install Gatsby and start a project: written for people without Gatsby or web development experience, though these learning resources have helped developers of all skill levels.
-2. [Quick start](/docs/quick-start): One page summary of how to install Gatsby and start a new project.
+1. [Tutorial](/tutorial/): Petunjuk langkah-demi-langkah tentang cara menginstal Gatsby dan memulai sebuah proyek: ditulis untuk orang tanpa pengalaman menggunakan Gatsby atau pengembangan web, meskipun sumber pembelajaran ini telah membantu para pengembang dari semua tingkat keterampilan.
+2. [Mulai cepat](/docs/quick-start): Ringkasan dalam satu halaman tentang cara menginstal Gatsby dan memulai proyek baru.
 
-## Go further
+## Lebih lanjut
 
-1. [Recipes](/docs/recipes/): Find some quick answers for how to accomplish some specific, common tasks with Gatsby.
-2. Choose your own adventure and peruse the various sections of the Gatsby docs:
+1. [Cara](/docs/recipes/): Temukan beberapa jawaban cepat untuk menyelesaikan beberapa tugas spesifik dan umum dengan Gatsby.
+2. Pilih petualangan Anda sendiri dan baca dengan teliti berbagai bagian pada dokumen Gatsby:
 
-   - [Reference Guides](/docs/guides/): Learn about the many different topics around building with Gatsby, like sourcing data, deployment, and more.
-   - [Gatsby API Reference](/docs/api-reference/): Learn more about Gatsby APIs and configuration.
-   - [Releases & Migration](/docs/releases-and-migration/): Find release notes and guides for migration between major versions.
-   - [Conceptual Guide](/docs/conceptual-guide/): Read high-level overviews of the Gatsby approach.
-   - [Gatsby Internals](/docs/gatsby-internals/): Dig into how Gatsby works behind the scenes.
-   - [Using Gatsby Professionally](/docs/using-gatsby-professionally/): Learn tips and tricks for how to explain Gatsby to others at work, so that you have more opportunities to work with Gatsby professionally.
+   - [Panduan Referensi](/docs/guides/): Pelajari tentang berbagai topik berbeda seputar membangun dengan Gatsby, seperti sumber data, *deployment*, dan banyak lagi.
+   - [Referensi API Gatsby](/docs/api-reference/): Pelajari lebih lanjut tentang API dan konfigurasi Gatsby.
+   - [Rilis & Migrasi](/docs/releases-and-migration/): Temukan beberapa catatan rilis dan panduan untuk migrasi antar versi utama.
+   - [Panduan Konseptual](/docs/conceptual-guide/): Baca gambaran tingkat tinggi dari pendekatan Gatsby.
+   - [Internal Gatsby](/docs/gatsby-internals/): Gali bagaimana Gatsby bekerja di belakang layar.
+   - [Menggunakan Gatsby secara Profesional](/docs/using-gatsby-professionally/): Pelajari kiat dan trik untuk bagaimana cara menjelaskan Gatsby kepada orang lain di tempat kerja, sehingga Anda memiliki lebih banyak peluang untuk bekerja dengan Gatsby secara profesional.
 
-3. Check out the [Ecosystem](/ecosystem/) libraries for Gatsby starters and plugins, as well as external community resources.
+3. Lihatlah perpustakaan [Ekosistem](/ecosystem/) untuk permulaan dan *plugins* Gatsby, serta sumber daya komunitas eksternal.
 
-## Start contributing
+## Mulai berkontribusi
 
-Visit the [Contributing](/contributing/) section to find guides on the Gatsby community, code of conduct, and how to get started contributing to Gatsby.
+Kunjungi bagian [Berkontribusi](/contributing/) untuk menemukan panduan tentang komunitas Gatsby, kode etik, dan cara memulai berkontribusi ke Gatsby.
 
 <EmailCaptureForm signupMessage="Want to keep up with the latest tips &amp; tricks? Subscribe to our newsletter!" />

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -12,24 +12,24 @@ Gatsby adalah sebuah *generator* situs modern yang cepat untuk React.
 Ada dua cara utama untuk memulai dengan Gatsby:
 
 1. [Tutorial](/tutorial/): Petunjuk langkah-demi-langkah tentang cara menginstal Gatsby dan memulai sebuah proyek: ditulis untuk orang tanpa pengalaman menggunakan Gatsby atau pengembangan web, meskipun sumber pembelajaran ini telah membantu para pengembang dari semua tingkat keterampilan.
-2. [Mulai cepat](/docs/quick-start): Ringkasan dalam satu halaman tentang cara menginstal Gatsby dan memulai proyek baru.
+2. [Cara singkat](/docs/quick-start): Ringkasan dalam satu halaman tentang cara menginstal Gatsby dan memulai proyek baru.
 
 ## Lebih lanjut
 
-1. [Cara](/docs/recipes/): Temukan beberapa jawaban cepat untuk menyelesaikan beberapa tugas spesifik dan umum dengan Gatsby.
-2. Pilih petualangan Anda sendiri dan baca dengan teliti berbagai bagian pada dokumen Gatsby:
+1. [Cara](/docs/recipes/): Temukan beberapa jawaban singkat untuk menyelesaikan beberapa tugas spesifik dan umum dengan Gatsby.
+2. Pilih cara Anda sendiri dan baca dengan teliti berbagai bagian pada dokumen Gatsby:
 
-   - [Panduan Referensi](/docs/guides/): Pelajari tentang berbagai topik berbeda seputar membangun dengan Gatsby, seperti sumber data, *deployment*, dan banyak lagi.
+   - [Panduan Referensi](/docs/guides/): Pelajari tentang berbagai topik berbeda seputar membangun web/aplikasi dengan Gatsby, seperti sumber data, *deployment*, dan banyak lagi.
    - [Referensi API Gatsby](/docs/api-reference/): Pelajari lebih lanjut tentang API dan konfigurasi Gatsby.
    - [Rilis & Migrasi](/docs/releases-and-migration/): Temukan beberapa catatan rilis dan panduan untuk migrasi antar versi utama.
-   - [Panduan Konseptual](/docs/conceptual-guide/): Baca gambaran tingkat tinggi dari pendekatan Gatsby.
+   - [Panduan Konseptual](/docs/conceptual-guide/): Baca cara pendekatan atau konsep Gatsby secara garis besarnya.
    - [Internal Gatsby](/docs/gatsby-internals/): Gali bagaimana Gatsby bekerja di belakang layar.
    - [Menggunakan Gatsby secara Profesional](/docs/using-gatsby-professionally/): Pelajari kiat dan trik untuk bagaimana cara menjelaskan Gatsby kepada orang lain di tempat kerja, sehingga Anda memiliki lebih banyak peluang untuk bekerja dengan Gatsby secara profesional.
 
-3. Lihatlah perpustakaan [Ekosistem](/ecosystem/) untuk permulaan dan *plugins* Gatsby, serta sumber daya komunitas eksternal.
+3. Lihatlah perpustakaan [Ekosistem](/ecosystem/) untuk permulaan dan *plugins* Gatsby, serta baca juga bahan-bahan dari komunitas Gatsby diluar.
 
-## Mulai berkontribusi
+## Mulai kontribusi
 
-Kunjungi bagian [Berkontribusi](/contributing/) untuk menemukan panduan tentang komunitas Gatsby, kode etik, dan cara memulai berkontribusi ke Gatsby.
+Kunjungi bagian [Kontribusi](/contributing/) untuk menemukan panduan tentang komunitas Gatsby, kode etik, dan cara memulai berkontribusi ke Gatsby.
 
 <EmailCaptureForm signupMessage="Want to keep up with the latest tips &amp; tricks? Subscribe to our newsletter!" />


### PR DESCRIPTION
Translated docs/index. But there's no index.md file before in docs/docs/ so i have to add the english version first. To compare, please refer to [this commit](https://github.com/gatsbyjs/gatsby-id/commit/88538c4aad2fec11299d3f128df678d4e797a2e0) or [this page](https://www.gatsbyjs.org/docs/).

Please kindly review my work, thanks.